### PR TITLE
FEAT/OPTIM: Added a flag to enable/disable the homenode check in storage operations and modified to enable empty values to be provided to make the storage operation read only.

### DIFF
--- a/handlerCreate.go
+++ b/handlerCreate.go
@@ -217,7 +217,7 @@ func Create(s *Services, h string, q url.Values) (string, error) {
 				return "", fmt.Errorf(
 					"Pair does not contain valid conflict flag")
 			}
-			o.values = append(o.values, p)
+			o.resolved = append(o.resolved, p)
 		}
 	}
 
@@ -242,9 +242,10 @@ func Create(s *Services, h string, q url.Values) (string, error) {
 	return u.String(), nil
 }
 
+// Creates a key value pair from the k and v values provided. If the v parameter
+// is an empty string then the operation will try and retrieve the existing
+// value for the key and will not update it.
 func createPair(k string, v string) (*pair, error) {
-	var err error
-	var p pair
 
 	// Get the command for the storage operation.
 	i := operationCharacterRegEx.FindStringIndex(k)
@@ -252,13 +253,53 @@ func createPair(k string, v string) (*pair, error) {
 		return nil, fmt.Errorf("Key '%s' must include a '+' to add the value "+
 			"to a list of values, or '<' (oldest wins) or '>' (newest wins) "+
 			"character to determine how to resolve two values for the same "+
-			"key, followed by a date in YYYY-MM-DD format to indicate when "+
-			"the value expires and is automatically deleted", k)
+			"key. If a value is provided this character must be followed by "+
+			"a date in YYYY-MM-DD format to indicate when "+
+			"the provided value expires and is automatically deleted.", k)
 	}
 	if len(i) > 2 || i[1]-i[0] != 1 {
 		return nil, fmt.Errorf(
 			"Key '%s' must contained only one '+', '<' or '>' character", k)
 	}
+
+	// If there is an expiry date then this indicates that the caller wishes
+	// to write the value to the network if other values don't exist.
+	if len(k)-1 != i[0] {
+		return createPairWithValue(k, v, i)
+	}
+	return createPairWithNoValue(k, i)
+}
+
+func getConflictPolicy(k string, i []int) (byte, error) {
+	switch k[i[0]] {
+	case '+':
+		return conflictAdd, nil
+	case '<':
+		return conflictOldest, nil
+	case '>':
+		return conflictNewest, nil
+	default:
+		return conflictInvalid, fmt.Errorf("Character '%c' invalid", k[i[0]])
+	}
+}
+
+func createPairWithNoValue(k string, i []int) (*pair, error) {
+	var err error
+	var p pair
+
+	// Create a valueless pair for the key with the provided conflict policy
+	// to retrieve existing values from the network.
+	p.key = k[:i[0]]
+	p.conflict, err = getConflictPolicy(k, i)
+	if err != nil {
+		return nil, err
+	}
+	return &p, err
+}
+
+func createPairWithValue(k string, v string, i []int) (*pair, error) {
+	var err error
+	var p pair
 
 	// Turn the value into a byte array. If the value is a base 64 string then
 	// use the resulting byte array. If it is not a base 64 string then use the
@@ -269,18 +310,9 @@ func createPair(k string, v string) (*pair, error) {
 	}
 
 	// Set how multiple values for the same key are handled.
-	switch k[i[0]] {
-	case '+':
-		p.conflict = conflictAdd
-		break
-	case '<':
-		p.conflict = conflictOldest
-		break
-	case '>':
-		p.conflict = conflictNewest
-		break
-	default:
-		return nil, fmt.Errorf("Character '%c' invalid", k[i[0]])
+	p.conflict, err = getConflictPolicy(k, i)
+	if err != nil {
+		return nil, err
 	}
 
 	// Work out the expiry time from the date that appears after the conflict
@@ -298,6 +330,7 @@ func createPair(k string, v string) (*pair, error) {
 	p.created = time.Now().UTC()
 	p.key = k[:i[0]]
 	p.values = [][]byte{b}
+
 	return &p, err
 }
 

--- a/handlerCreate.go
+++ b/handlerCreate.go
@@ -44,6 +44,7 @@ const (
 	stateParam                 = "state"
 	displayUserInterfaceParam  = "displayUserInterface"
 	postMessageOnCompleteParam = "postMessageOnComplete"
+	useHomeNode                = "useHomeNode"
 )
 
 // Used to determine the storage character from the key to use for the
@@ -149,9 +150,13 @@ func Create(s *Services, h string, q url.Values) (string, error) {
 
 	// Check the flag for the posting of a message on completion rather than
 	// using the return URL.
-	if q.Get(postMessageOnCompleteParam) == "true" {
-		o.SetPostMessageOnComplete(true)
-	}
+	o.SetPostMessageOnComplete(q.Get(postMessageOnCompleteParam) == "true")
+
+	// Check the flag for the display of the user interface.
+	o.SetDisplayUserInterface(q.Get(displayUserInterfaceParam) != "false")
+
+	// Check the flag for the use of the home node if it contains current data.
+	o.SetUseHomeNode(q.Get(useHomeNode) != "false")
 
 	// Set the return URL to use when posting the message or to redirect the
 	// browser to with the encrypted SWAN data appended.
@@ -161,15 +166,11 @@ func Create(s *Services, h string, q url.Values) (string, error) {
 	}
 	o.returnURL = ru.String()
 
-	// Set the table that will be used for the storage of the key value
-	// pairs.
+	// Set the table that will be used for the storage of the key value pairs.
 	o.table = q.Get(tableParam)
 	if o.table == "" {
 		return "", fmt.Errorf("Missing table name")
 	}
-
-	// Check the flag for the display of the user interface.
-	o.SetDisplayUserInterface(q.Get(displayUserInterfaceParam) != "false")
 
 	// Set the browser warning probability if provided.
 	b, err := strconv.ParseFloat(q.Get(browserWarningParam), 32)
@@ -399,7 +400,8 @@ func isReserved(s string) bool {
 		s == nodeCount ||
 		s == stateParam ||
 		s == displayUserInterfaceParam ||
-		s == postMessageOnCompleteParam
+		s == postMessageOnCompleteParam ||
+		s == useHomeNode
 }
 
 // validateURL confirms that the parameter is a valid URL and then returns the

--- a/handlerStore.go
+++ b/handlerStore.go
@@ -88,16 +88,11 @@ func HandlerStore(
 
 		if o.nextNode != nil {
 
-			// Process any cookies to make sure this node stores the current
-			// version of the data.
-			err = o.processCookies(w, r)
-			if err != nil && s.config.Debug {
-				log.Println(err.Error())
-			}
-
-			// If this is the first node and all the cookies are valid then
-			// there is no need to continue bouncing.
-			if o.nodesVisited <= 1 && o.getCookiesValid() {
+			// If this is the first node, there are values in cookies for all
+			// the keys of the operation, and those values have not expired
+			// meaning the rest of the network does not need to be consulted to
+			// complete the operation.
+			if o.nodesVisited == 1 && o.getCookiesValid() {
 				o.storeComplete(s, w, r)
 			} else {
 				o.storeContinue(s, w, r)
@@ -105,24 +100,17 @@ func HandlerStore(
 
 		} else {
 
-			// Process any cookies to make sure this node stores the current
-			// version of the data.
-			err = o.processCookies(w, r)
-			if err != nil && s.config.Debug {
-				log.Println(err.Error())
-			}
-
 			// If this is the home node and the last operation of a multi node
 			// operation then validate that cookies are available. If not then a
 			// warning will need to be shown and the next node will be the home
 			// node. Otherwise return to the returnURL.
-			if o.getCookiesPresent() == false && o.nodeCount > 1 {
+			if o.getAllCookiesPresent() == false &&
+				o.nodesVisited == o.nodeCount {
 				o.storeWarning(s, w, r)
 			} else {
 				o.storeComplete(s, w, r)
 			}
 		}
-
 	}
 }
 
@@ -152,9 +140,10 @@ func (o *operation) storeWarning(
 	var err error
 
 	// The next node after the cookies have been set is the home node. The
-	// counter will also need to be reset to zero.
+	// counter and the time stamp will also need to be reset to zero.
 	o.nextNode = o.HomeNode()
 	o.nodesVisited = 0
+	o.timeStamp = time.Now().UTC()
 
 	// Get the next URL for the node.
 	o.nextURL, err = o.getNextURL()
@@ -226,6 +215,9 @@ func (o *operation) storeReturn(
 	}
 	nu += x
 
+	// Sets cookies for any non empty resolved pairs.
+	o.setCookies(s, w, r)
+
 	// Turn the next URL string into a url.URL value.
 	o.nextURL, err = url.Parse(nu)
 	if err != nil {
@@ -257,6 +249,9 @@ func (o *operation) storeContinue(
 		return
 	}
 
+	// Sets cookies for any non empty resolved pairs.
+	o.setCookies(s, w, r)
+
 	// Set the preload header to trigger a DNS lookup on the next domain before
 	// the request to that domain occurs via the navigation change. Only do this
 	// if the next node is not the home node which will have already been
@@ -284,11 +279,27 @@ func (o *operation) storeContinue(
 	}
 }
 
+// setCookies for all the resolved pairs that are not empty.
+func (o *operation) setCookies(
+	s *Services,
+	w http.ResponseWriter,
+	r *http.Request) {
+	for _, p := range o.resolved {
+		if p.isEmpty() == false {
+			err := o.setValueInCookie(w, r, p)
+			if err != nil {
+				returnServerError(s, w, err)
+				return
+			}
+		}
+	}
+}
+
 func (o *operation) getResults() (string, error) {
 
 	// Build the results array of key value pairs.
 	var r Results
-	for _, p := range o.values {
+	for _, p := range o.resolved {
 		r.pairs = append(r.pairs, &p.Pair)
 	}
 
@@ -357,92 +368,4 @@ func (o *operation) asURLParameter() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(e), err
-}
-
-// For each of the keys that this operation is concerned with find the value
-// from the cookies if there is a cookie that shares the key. If there is no
-// cookie already for the key then set one in the response.
-func (o *operation) processCookies(
-	w http.ResponseWriter,
-	r *http.Request) error {
-	for _, p := range o.values {
-		c, err := r.Cookie(o.thisNode.scramble(p.key))
-		if err != nil {
-
-			// If there was a problem getting the cookie then just write the
-			// new cookie from the operational pair.
-			err = o.setValueInCookie(w, r, p)
-
-		} else {
-
-			// Process the cookie and the operational pair to determine which
-			// one should be used for the value, or if a list of values if they
-			// should be combined.
-			err = processCookie(w, r, o, p, c)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// processCookie determines if the cookie value contained in c should be used
-// OR if the operational data in p should be used. The cookie is then updated
-// with the value selected.
-// w the http response writer
-// r the http request
-// o the storage operation
-// op the current key value pair for the storage operation
-// c the cookie related to the key of p the contains value for this storage node
-func processCookie(
-	w http.ResponseWriter,
-	r *http.Request,
-	o *operation,
-	op *pair,
-	c *http.Cookie) error {
-
-	// op = operation pair
-	// cp = cookie pair
-	// rp = resolved pair - the pair after conflict resolution
-
-	// Decrypt the cookie value, and continue if valid.
-	cp, err := o.thisNode.getValueFromCookie(c)
-	if err != nil {
-
-		// The current cookie is invalid and can't be used. Set the cookie to
-		// the operations value.
-		o.setValueInCookie(w, r, op)
-
-	} else {
-
-		// Resolve the conflict between the operation's value and the one found
-		// in the cookie.
-		rp, err := resolveConflict(op, cp)
-		if err != nil {
-			return err
-		}
-
-		// Update the cookie for this node with the resolved value. Even if the
-		// value is not changing the pair.cookieWriteTime field needs to be
-		// updated to indicate to subsequent operations when the data was last
-		// current.
-		err = o.setValueInCookie(w, r, rp)
-		if err != nil {
-			return err
-		}
-
-		// If the a pair other than the operational pair was chosen then update
-		// the operational pair.
-		if rp != op {
-			op.conflict = rp.conflict
-			op.created = rp.created
-			op.expires = rp.expires
-			op.key = rp.key
-			op.values = rp.values
-			op.cookieWriteTime = rp.cookieWriteTime
-		}
-	}
-
-	return nil
 }

--- a/handlerStore.go
+++ b/handlerStore.go
@@ -88,11 +88,12 @@ func HandlerStore(
 
 		if o.nextNode != nil {
 
-			// If this is the first node, there are values in cookies for all
-			// the keys of the operation, and those values have not expired
-			// meaning the rest of the network does not need to be consulted to
-			// complete the operation.
-			if o.nodesVisited == 1 && o.getCookiesValid() {
+			// If this is the first node (the home node), the home alone can be
+			// used if it contains a current version of the values, there are
+			// values in cookies for all the keys of the operation, and those
+			// values have not expired meaning the rest of the network does not
+			// need to be consulted to complete the operation.
+			if o.nodesVisited == 1 && o.UseHomeNode() && o.getCookiesValid() {
 				o.storeComplete(s, w, r)
 			} else {
 				o.storeContinue(s, w, r)

--- a/html.go
+++ b/html.go
@@ -23,6 +23,7 @@ import "bytes"
 const (
 	flagDisplayUserInterface  = iota
 	flagPostMessageOnComplete = iota
+	flagUseHomeNode           = iota
 )
 
 // HTML parameters that control the function and display of the user interface.
@@ -82,6 +83,30 @@ func (h *HTML) SetPostMessageOnComplete(v bool) {
 		h.setBit(flagPostMessageOnComplete)
 	} else {
 		h.clearBit(flagPostMessageOnComplete)
+	}
+}
+
+// UseHomeNode true if the home node can be used if it contains current data.
+// False if the SWAN network should be consulted irrespective of the state of
+// data held on the home node.
+func (h *HTML) UseHomeNode() bool {
+	return h.hasBit(flagUseHomeNode)
+}
+
+// UseHomeNodeAsString returns the flag as a string. Either "true" or "false".
+func (h *HTML) UseHomeNodeAsString() string {
+	if h.PostMessageOnComplete() {
+		return "true"
+	}
+	return "false"
+}
+
+// SetUseHomeNode sets the flag to true or false.
+func (h *HTML) SetUseHomeNode(v bool) {
+	if v {
+		h.setBit(flagUseHomeNode)
+	} else {
+		h.clearBit(flagUseHomeNode)
 	}
 }
 

--- a/htmlTemplates.go
+++ b/htmlTemplates.go
@@ -21,16 +21,9 @@ import (
 	"strings"
 )
 
-var progressTemplate = newHTMLTemplate("progress", `
-<!DOCTYPE html>
-<html lang="{{.Language}}">
-<head>
-	<meta charset="utf-8" />
-	<title>{{.Title}}</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel="icon" href="data:;base64,=">
-</head>
-<body style="margin: 0;
+var bodyStyle = `
+body {
+	margin: 0;
 	padding: 0;
 	font-family: nunito, sans-serif;
 	font-size: 16px;
@@ -40,66 +33,82 @@ var progressTemplate = newHTMLTemplate("progress", `
 	height: 100vh;         
 	display: flex;
 	justify-content: center;
-	align-items: center;">
-	<table style="text-align: center;">
-		<tr>
-			<td>
-				<p style="padding-bottom: 2.5em;">{{.Message}}</p>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<div style="display:grid; width: {{.SVGSize}}px; margin: auto; line-height: {{.SVGSize}}px;">
-					<style>
-						div, svg {
-							grid-column: 1;
-							grid-row: 1;
-						}
-					</style>
-					<div>{{.PercentageComplete}}%</div>
-					<svg style="z-index: -1; stroke:{{.ProgressColor}}; fill:none; stroke-width: {{.SVGStroke}}; width: {{.SVGSize}}px; height: {{.SVGSize}}px;">
-						<path d="{{.SVGPath}}"></path>
-					</svg>
-				</div>
-			</td>
-		</tr>
-		{{if .Debug}}
-		<tr>
-			<td>
-				<style>
-					.debug {
-						text-align:left;
-						font-weight:initial;
-					}
-					.debug tr td {
-						word-wrap:break-word;
-						word-break:break-all;
-					}
-				</style>
-				<table class="debug">
-					<tr><th>TimeStamp:</th><td>{{.TimeStamp}}</td></tr>
-					<tr><th>TimeValid:</th><td>{{.IsTimeStampValid}}</td></tr>
-					<tr><th>ReturnUrl:</th><td>{{.ReturnURL}}</td></tr>
-					<tr><th>AccessNode:</th><td>{{.AccessNode}}</td></tr>
-					<tr><th>HomeNode:</th><td>{{.HomeNode.Domain}}</td></tr>
-					<tr><th>NodesVisited:</th><td>{{.NodesVisited}}</td></tr>
-					<tr><th>NodeCount:</th><td>{{.NodeCount}}</td></tr>
-					<tr><th>NextURL:</th><td>{{.NextURL}}</td></tr>
-				</table>
-				<table class="debug">
-				<tr><th>Key</th><th>Value</th><th>Created</th><th>Expires</th><th>Conflict</th></tr>
-				{{range .Values}} 
-				<tr><td>{{.Key}}</td><td>{{.Value}}</td><td>{{.Created}}</td><td>{{.Expires}}</td><td>{{.Conflict}}</td></tr>
-				{{end}}
-				</table>
-			</td>
-		</tr>
-		<tr><td><a href="{{.NextURL}}">Next</a></td></tr>
-		{{else}}
-		<meta http-equiv="refresh" content="0;URL='{{.NextURL}}'"/>
-		{{end}}        
-	</table>
-</body>
+	align-items: center; }
+table {
+	text-align: center; }
+`
+
+var progressRedirect = `
+{{if .Debug}}
+<tr>
+	<td>
+		<style>
+			.debug {
+				text-align:left;
+				font-weight:initial;
+			}
+			.debug tr td {
+				word-wrap:break-word;
+				word-break:break-all;
+			}
+		</style>
+		<table class="debug">
+			<tr><th>TimeStamp:</th><td>{{.TimeStamp}}</td></tr>
+			<tr><th>TimeValid:</th><td>{{.IsTimeStampValid}}</td></tr>
+			<tr><th>ReturnUrl:</th><td>{{.ReturnURL}}</td></tr>
+			<tr><th>AccessNode:</th><td>{{.AccessNode}}</td></tr>
+			<tr><th>HomeNode:</th><td>{{.HomeNode.Domain}}</td></tr>
+			<tr><th>NodesVisited:</th><td>{{.NodesVisited}}</td></tr>
+			<tr><th>NodeCount:</th><td>{{.NodeCount}}</td></tr>
+			<tr><th>NextURL:</th><td>{{.NextURL}}</td></tr>
+		</table>
+		<table class="debug">
+		<tr><th>Key</th><th>Value</th><th>Created</th><th>Expires</th><th>Conflict</th></tr>
+		{{range .Values}} 
+		<tr><td>{{.Key}}</td><td>{{.Value}}</td><td>{{.Created}}</td><td>{{.Expires}}</td><td>{{.Conflict}}</td></tr>
+		{{end}}
+		</table>
+	</td>
+</tr>
+<tr><td><a href="{{.NextURL}}">Next</a></td></tr>
+{{else}}
+<meta http-equiv="refresh" content="0;URL='{{.NextURL}}'"/>
+{{end}}`
+
+var progressUI = `
+<tr>
+	<td>
+		<p style="padding-bottom: 2.5em;">{{.Message}}</p>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div style="display:grid; width: {{.SVGSize}}px; margin: auto; line-height: {{.SVGSize}}px;">
+			<style>
+				div, svg {
+					grid-column: 1;
+					grid-row: 1;
+				}
+			</style>
+			<div>{{.PercentageComplete}}%</div>
+			<svg style="z-index: -1; stroke:{{.ProgressColor}}; fill:none; stroke-width: {{.SVGStroke}}; width: {{.SVGSize}}px; height: {{.SVGSize}}px;">
+				<path d="{{.SVGPath}}"></path>
+			</svg>
+		</div>
+	</td>
+</tr>`
+
+var progressTemplate = newHTMLTemplate("progress", `
+<!DOCTYPE html>
+<html lang="{{.Language}}">
+<head>
+	<meta charset="utf-8" />
+	<title>{{.Title}}</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="icon" href="data:;base64,=">
+	<style>`+bodyStyle+`</style>
+</head>
+<body><table>`+progressUI+progressRedirect+`</table></body>
 </html>`)
 
 var blankTemplate = newHTMLTemplate("blank", `
@@ -122,18 +131,9 @@ var malformedTemplate = newHTMLTemplate("malformed", `
 	<title>Bad Request</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="icon" href="data:;base64,=">
+	<style>`+bodyStyle+`</style>
 </head>
-<body style="margin: 0;
-	padding: 0;
-	font-family: nunito, sans-serif;
-	font-size: 16px;
-	font-weight: 600;
-	background-color: {{.BackgroundColor}};
-	color: {{.MessageColor}};
-	height: 100vh;         
-	display: flex;
-	justify-content: center;
-	align-items: center;">
+<body>
 	<table style="text-align: center; background-color: white; padding: 1em; border: solid black 2px;">
 		<tr>
 			<td>
@@ -158,18 +158,9 @@ var registerTemplate = newHTMLTemplate("register", `
 	<title>Shared Web State - Register Node</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="icon" href="data:;base64,=">
+	<style>`+bodyStyle+`</style>
 </head>
-<body style="margin: 0;
-	padding: 0;
-	font-family: nunito, sans-serif;
-	font-size: 16px;
-	font-weight: 600;
-	background-color: {{.Services.Config.BackgroundColor}};
-	color: {{.Services.Config.MessageColor}};
-	height: 100vh;         
-	display: flex;
-	justify-content: center;
-	align-items: center;">
+<body>
 	<form action="register" method="GET">
 	<table style="text-align: left;">
 		<tr>
@@ -255,18 +246,9 @@ var warningTemplate = newHTMLTemplate("warning", `
 	<title>{{.Title}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="icon" href="data:;base64,=">
+	<style>`+bodyStyle+`</style>
 </head>
-<body style="margin: 0;
-	padding: 0;
-	font-family: nunito, sans-serif;
-	font-size: 16px;
-	font-weight: 600;
-	background-color: {{.BackgroundColor}};
-	color: {{.MessageColor}};
-	height: 100vh;         
-	display: flex;
-	justify-content: center;
-	align-items: center;">
+<body>
 	<table style="text-align: center; background-color: white; padding: 1em; border: solid black 2px;">
 		<tr>
 			<td>
@@ -322,8 +304,9 @@ var postMessageTemplate = newHTMLTemplate("postMessage", `
 <head>
 	<meta charset="utf-8" />
 	<link rel="icon" href="data:;base64,=">
+	<style>`+bodyStyle+`</style>
 </head>
-<body style="background-color: {{.BackgroundColor}}">
+<body><table>`+progressUI+`</table>
 	<script>
 		window.opener.postMessage("{{.Results}}","{{.ReturnURL}}");
 	</script>

--- a/operation.go
+++ b/operation.go
@@ -78,6 +78,7 @@ func (o *operation) NodeCount() byte         { return o.nodeCount }
 func (o *operation) Debug() bool             { return o.services.config.Debug }
 func (o *operation) SVGStroke() int          { return svgStroke }
 func (o *operation) SVGSize() int            { return svgSize }
+func (o *operation) Values() []*pair         { return o.resolved }
 
 // Results of the operation to return to the caller.
 func (o *operation) Results() (string, error) {
@@ -254,7 +255,8 @@ func newOperationFromRequest(
 
 // getCookiesValid confirms that the cookies that are present were written
 // within the home node timeout and are still valid. This can be used to
-// determine if the rest of the network needs to be checked.
+// determine if the rest of the network needs to be checked. If there is no
+// cookie then the cookie is not valid because they are incomplete.
 func (o *operation) getCookiesValid() bool {
 	t := time.Now().UTC()
 	for _, p := range o.resolved {
@@ -264,6 +266,8 @@ func (o *operation) getCookiesValid() bool {
 				c.cookieWriteTime.Before(t) {
 				t = c.cookieWriteTime
 			}
+		} else {
+			return false
 		}
 	}
 	d := time.Now().UTC().Sub(t) / time.Second


### PR DESCRIPTION
The flag useHomeNode=true/false can be used to enable or disable the home node check in the storage operation. As the home node check is verifying that all the cookies held are within the current time limit and are not empty it does not check to determine if the values match the current storage operation. This is okay when a read request is occurring, however when the UIP triggers an update and new data is explicitly being written to the network the presence of value isn't enough to verify only the home node can be used. This flag enables the caller to bypass the check and is likely to be used for write operations.

The operation now enables empty values to be provided rather than requiring a default value to be provided if a value does not already exist for the key in the network. This enables the SWIFT layer to avoid writing cookies for empty values  but still be informed that the value for the key is required. The following key provided to SWIFT as a parameter would read the value for "key" and address any conflicts by choosing the most recent value.

"key>="

No cookie would be written for key as it has no value.

This change ensures that no cookies are written to the web browser until after values have been provided. For SWAN this is important for the User Interface Provider to ensure their dialogue has been displayed and the user enter their preferences before anything is written.